### PR TITLE
README: Fix spelling and add new LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # altstore-beta
-A modified version of Altstore apps.json. Containing only beta apps and making them visible to non-paterons.
+
+A modified version of Altstore apps.json. Containing only beta apps
+and making them visible to non-paterons.
 
 Updated hourly using GitHub actions.
 
-**Please note that some Ad blockers block all .gq domains.** I 
-will get an actual domain as soon as possible. Please add 
-nickchan.gq to your adblocker excpetions if you encounter 
-issues related to it. This site currently does not display ads 
+**Please note that some adblockers block all .gq domains.** I 
+will get an actual domain as soon as possible. Please add
+`nickchan.gq` to your adblocker exceptions if you encounter
+issues related to it. This site currently does not display ads
 or track you (other than what GitHub does on all GitHub pages - 
 I cannot control that). When the domain changes, the new URL 
-will always be available at 
-https://github.com/asdfugil/altstore-beta .
+will always be available at <https://github.com/asdfugil/altstore-beta>.
 
-Add this URL: `https://nickchan.gq/altstore-beta/apps.json`
+To use this repository, add `https://nickchan.gq/altstore-beta/apps.json`
+to your repository list in AltStore
 
 If your version of AltStore only allow 'trusted' sources, open 
 this URL in Safari: 
@@ -22,7 +24,6 @@ This repository does not host AltStore beta apps. It merely
 contains instructions for AltStore to download them from 
 [AltStore CDN](https://cdn.altstore.io).
 
-The contents of this repository is licensed under MIT license, 
-with the exception of apps.json and apps-safe.json, which is 
-licensed under AGPLv3 (see 
-[apps.json_LICENSE](apps.json_LICENSE)).
+The contents of this repository are licensed under the MIT
+license, with the exception of `apps.json` and `apps-safe.json`,
+which are licensed under AGPLv3 (see [LICENSE](LICENSE))


### PR DESCRIPTION
This small PR fixes spelling errors and adds the link to the project license, while remove any reference of the old license file.